### PR TITLE
Call onNodeClick when reset click to root

### DIFF
--- a/src/sunburst.js
+++ b/src/sunburst.js
@@ -108,7 +108,7 @@ export default Kapsule({
     });
 
     // Reset focus by clicking on canvas
-    state.svg.on('click', () => this.focusOnNode(null));
+    state.svg.on('click', () => (state.onNodeClick || this.focusOnNode)(state.data));
   },
 
   update: function(state) {


### PR DESCRIPTION
Fix weird behaviour when clicking outside of the chart. The callback onNodeClick was not called.