### PR TITLE
maximize space-fill when d.height < state.maxLevels

### DIFF
--- a/src/sunburst.js
+++ b/src/sunburst.js
@@ -145,7 +145,8 @@ export default Kapsule({
     const transition = d3Transition().duration(TRANSITION_DURATION);
 
     const levelYDelta = state.layoutData[0].y1 - state.layoutData[0].y0;
-    const maxY = state.maxLevels ? Math.min(1, focusD.y0 + state.maxLevels * levelYDelta) : 1;
+    const crntMaxLvlv = state.maxLevels ? Math.min(state.maxLevels, focusD.height + 1 || state.maxLevels) : 1;
+    const maxY = state.maxLevels ? Math.min(1, focusD.y0 + crntMaxLvl * levelYDelta) : 1;
 
     // Apply zoom
     state.svg.transition(transition)

--- a/src/sunburst.js
+++ b/src/sunburst.js
@@ -145,8 +145,10 @@ export default Kapsule({
     const transition = d3Transition().duration(TRANSITION_DURATION);
 
     const levelYDelta = state.layoutData[0].y1 - state.layoutData[0].y0;
-    const crntMaxLvlv = state.maxLevels ? Math.min(state.maxLevels, focusD.height + 1 || state.maxLevels) : 1;
-    const maxY = state.maxLevels ? Math.min(1, focusD.y0 + crntMaxLvl * levelYDelta) : 1;
+    const maxY = Math.min(1, focusD.y0 + levelYDelta * Math.min(
+      focusD.hasOwnProperty('height') ? focusD.height + 1 : Infinity,
+      state.maxLevels || Infinity
+    ));
 
     // Apply zoom
     state.svg.transition(transition)


### PR DESCRIPTION
addresses issue of excess whitespace when zooming in on nodes near the bottom of the hierarchy, thus improves readability of labels