### PR TITLE
Fix default layout if using maxLevels and excludeRoot

### DIFF
--- a/src/sunburst.js
+++ b/src/sunburst.js
@@ -153,7 +153,7 @@ export default Kapsule({
             d.x1 >= focusD.x0
             && d.x0 <= focusD.x1
             && (d.x1-d.x0)/(focusD.x1-focusD.x0) > state.minSliceAngle/360
-            && (!state.maxLevels || d.depth - (focusD.depth || 0) < state.maxLevels)
+            && (!state.maxLevels || d.depth - (focusD.depth || (state.excludeRoot ? 1 : 0)) < state.maxLevels)
             && (d.y0 >=0 || focusD.parent) // hide negative layers on top level
           ),
         d => d.id


### PR DESCRIPTION
with maxLevels = # and excludeRoot(true) the initial display was showing #-1 layers and not using up all the available space, this fixes that