### PR TITLE
Add strokeThickness option to control arcs stroke width.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ myChart
 | <b>size</b>([<i>string</i> or <i>fn</i>]) | Getter/setter for a node object size accessor, used to compute the angles of the arcs. | `value` |
 | <b>color</b>([<i>string</i> or <i>fn</i>]) | Getter/setter for a node object color accessor, used to color fill the arcs. | <i>grey</i> |
 | <b>strokeColor</b>([<i>string</i> or <i>fn</i>]) | Getter/setter for a node object stroke color accessor, used to color the contour of the arcs. | <i>white</i> |
+| <b>strokeThickness</b>([<i>number</i> or <i>fn</i>]) | Getter/setter for a node object stroke width accessor, used adjust the width of the arcs. | `1` |
 | <b>minSliceAngle</b>([<i>number</i>]) | Getter/setter for the minimum angle of an arc (in degrees) required for it to be rendered in the DOM. | `0.2` |
 | <b>maxLevels</b>([<i>number</i>]) | Getter/setter for the maximum number of layers to show at any given time. | - |
 | <b>excludeRoot</b>([<i>boolean</i>]) | Getter/setter for whether to exclude the root node from the top level representation, to maximize the available radial space. | `false` |

--- a/src/sunburst.js
+++ b/src/sunburst.js
@@ -25,6 +25,7 @@ export default Kapsule({
     size: { default: 'value', onChange(_, state) { state.needsReparse = true }},
     color: { default: d => 'lightgrey' },
     strokeColor: { default: d => 'white' },
+    strokeThickness: { default: d => 1 },
     minSliceAngle: { default: .2 },
     maxLevels: {},
     excludeRoot: { default: false, onChange(_, state) { state.needsReparse = true }},
@@ -168,6 +169,7 @@ export default Kapsule({
     const nameOf = accessorFn(state.label);
     const colorOf = accessorFn(state.color);
     const strokeColorOf = accessorFn(state.strokeColor);
+    const strokeThicknessOf = accessorFn(state.strokeThickness);
     const transition = d3Transition().duration(TRANSITION_DURATION);
 
     const levelYDelta = state.layoutData[0].y1 - state.layoutData[0].y0;
@@ -203,7 +205,7 @@ export default Kapsule({
       .on('mouseover', (ev, d) => {
         ev.stopPropagation();
         state.onHover && state.onHover(d.data);
-        
+
         state.tooltip.style('display', state.showTooltip(d.data, d) ? 'inline' : 'none');
         state.tooltip.html(`<div class="tooltip-title">${
           state.tooltipTitle
@@ -219,6 +221,7 @@ export default Kapsule({
     newSlice.append('path')
       .attr('class', 'main-arc')
       .style('stroke', d => strokeColorOf(d.data, d.parent))
+      .style('stroke-width', d => strokeThicknessOf(d.data, d.parent))
       .style('fill', d => colorOf(d.data, d.parent));
 
     newSlice.append('path')
@@ -253,6 +256,7 @@ export default Kapsule({
     allSlices.select('path.main-arc').transition(transition)
       .attrTween('d', d => () => state.arc(d))
       .style('stroke', d => strokeColorOf(d.data, d.parent))
+      .style('stroke-width', d => strokeThicknessOf(d.data, d.parent))
       .style('fill', d => colorOf(d.data, d.parent));
 
     const computeAngularLabels = state.showLabels && ['angular', 'auto'].includes(state.labelOrientation.toLowerCase());


### PR DESCRIPTION
Hi, here a proposition to add a `strokeThickness` option, this allow to control stroke with for the arcs. Thicker stroke can be convenient to get better visual demarcation between arcs.