### PR TITLE
Add option to add css classes on labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ myChart
 | <b>size</b>([<i>string</i> or <i>fn</i>]) | Getter/setter for a node object size accessor, used to compute the angles of the arcs. | `value` |
 | <b>color</b>([<i>string</i> or <i>fn</i>]) | Getter/setter for a node object color accessor, used to color fill the arcs. | <i>grey</i> |
 | <b>strokeColor</b>([<i>string</i> or <i>fn</i>]) | Getter/setter for a node object stroke color accessor, used to color the contour of the arcs. | <i>white</i> |
+| <b>nodeClassName</b>([<i>string</i> or <i>fn</i>]) | Getter/setter for additional CSS classes to add on each slice node according to the node data. The function must return a string that contains your CSS classes to add. | |
 | <b>minSliceAngle</b>([<i>number</i>]) | Getter/setter for the minimum angle of an arc (in degrees) required for it to be rendered in the DOM. | `0.2` |
 | <b>maxLevels</b>([<i>number</i>]) | Getter/setter for the maximum number of layers to show at any given time. | - |
 | <b>excludeRoot</b>([<i>boolean</i>]) | Getter/setter for whether to exclude the root node from the top level representation, to maximize the available radial space. | `false` |

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -50,6 +50,8 @@ export interface SunburstChartGenericInstance<ChainableInstance> {
   color(colorAccessor: NodeAccessor<string>): ChainableInstance;
   strokeColor(): NodeAccessor<string>;
   strokeColor(colorAccessor: NodeAccessor<string>): ChainableInstance;
+  nodeClassName(): NodeAccessor<string>;
+  nodeClassName(nodeAccessor: NodeAccessor<string>): ChainableInstance;
 
   minSliceAngle(): number;
   minSliceAngle(degrees: number): ChainableInstance;

--- a/src/sunburst.js
+++ b/src/sunburst.js
@@ -22,6 +22,7 @@ export default Kapsule({
     sort: { onChange(_, state) { state.needsReparse = true }},
     label: { default: d => d.name },
     labelOrientation: { default: 'auto' }, // angular, radial, auto
+    nodeClassName: { default: d => '' }, // Additional css classes to add on each slice node
     size: { default: 'value', onChange(_, state) { state.needsReparse = true }},
     color: { default: d => 'lightgrey' },
     strokeColor: { default: d => 'white' },
@@ -165,6 +166,7 @@ export default Kapsule({
         d => d.id
       );
 
+    const nodeClassNameOf = accessorFn(state.nodeClassName);
     const nameOf = accessorFn(state.label);
     const colorOf = accessorFn(state.color);
     const strokeColorOf = accessorFn(state.strokeColor);
@@ -194,7 +196,7 @@ export default Kapsule({
 
     // Entering
     const newSlice = slice.enter().append('g')
-      .attr('class', 'slice')
+      .attr('class', (d) => `slice ${nodeClassNameOf(d.data)}`)
       .style('opacity', 0)
       .on('click', (ev, d) => {
         ev.stopPropagation();
@@ -203,7 +205,7 @@ export default Kapsule({
       .on('mouseover', (ev, d) => {
         ev.stopPropagation();
         state.onHover && state.onHover(d.data);
-        
+
         state.tooltip.style('display', state.showTooltip(d.data, d) ? 'inline' : 'none');
         state.tooltip.html(`<div class="tooltip-title">${
           state.tooltipTitle


### PR DESCRIPTION
Hi, this add an option to add custom css class(es) in addition to `radial-label` and `angular-label` on texts. In my case i need to change the text color  according to the node, so by adding a custom css class it's now possible to change the color from the css.