### PR TITLE
Added Fallback for Offscreen Canvas

### DIFF
--- a/src/text.js
+++ b/src/text.js
@@ -3,7 +3,14 @@ const measureTextWidth = (
   fontSize = 16,
   { strokeWidth = 1, fontFamily = 'sans-serif' } = {},
 ) => {
-  const ctx = new OffscreenCanvas(0, 0).getContext('2d');
+  let ctx;
+  if (typeof OffscreenCanvas !== 'undefined') {
+    ctx = new OffscreenCanvas(0, 0).getContext('2d');
+  } else {
+    const canvas = document.createElement('canvas');
+    ctx = canvas.getContext('2d');
+  }
+
   if (!ctx) return 0;
 
   ctx.font = `${fontSize}px ${fontFamily}`;


### PR DESCRIPTION
OffScreencanvas isn't supported by all browsers, this uses OffScreencanvas when available and provides a fallback when its not available.